### PR TITLE
Add test vectors for signing messages.

### DIFF
--- a/manual.json
+++ b/manual.json
@@ -23282,5 +23282,119 @@
       "13 | Args hash [3/3] : fb6d32",
       "14 | Approvals # : 3"
     ]
+  },
+  {
+    "index": 513,
+    "name": "valid-casper-message",
+    "valid_regular": true,
+    "valid_expert": true,
+    "testnet": true,
+    "blob": "436173706572204d6573736167653a0a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
+    "output": [
+      "0 | Sign msg [1/4] : 436173706572204d6573736167653a0a50",
+      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
+      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
+      "0 | Sign msg [4/4] : 6e"
+    ],
+    "output_expert": [
+      "0 | Sign msg [1/4] : 436173706572204d6573736167653a0a50",
+      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
+      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
+      "0 | Sign msg [4/4] : 6e"
+    ]
+  },
+  {
+    "index": 514,
+    "name": "invalid-casper-message",
+    "valid_regular": false,
+    "valid_expert": false,
+    "testnet": true,
+    "blob": "4361737065723a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
+    "output": [
+      "0 | Sign msg [1/3] : 4361737065723a506c6561736520736967",
+      "0 | Sign msg [2/3] : 6e2074686973204353505220746f6b656e",
+      "0 | Sign msg [3/3] : 20646f6e6174696f6e"
+    ],
+    "output_expert": [
+      "0 | Sign msg [1/3] : 4361737065723a506c6561736520736967",
+      "0 | Sign msg [2/3] : 6e2074686973204353505220746f6b656e",
+      "0 | Sign msg [3/3] : 20646f6e6174696f6e"
+    ]
+  },
+  {
+    "index": 515,
+    "name": "invalid-casper-message",
+    "valid_regular": false,
+    "valid_expert": false,
+    "testnet": true,
+    "blob": "4361737065724d6573736167653a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
+    "output": [
+      "0 | Sign msg [1/3] : 4361737065724d6573736167653a506c65",
+      "0 | Sign msg [2/3] : 617365207369676e207468697320435350",
+      "0 | Sign msg [3/3] : 5220746f6b656e20646f6e6174696f6e"
+    ],
+    "output_expert": [
+      "0 | Sign msg [1/3] : 4361737065724d6573736167653a506c65",
+      "0 | Sign msg [2/3] : 617365207369676e207468697320435350",
+      "0 | Sign msg [3/3] : 5220746f6b656e20646f6e6174696f6e"
+    ]
+  },
+  {
+    "index": 516,
+    "name": "invalid-casper-message",
+    "valid_regular": false,
+    "valid_expert": false,
+    "testnet": true,
+    "blob": "4361737065723a0a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
+    "output": [
+      "0 | Sign msg [1/3] : 4361737065723a0a506c65617365207369",
+      "0 | Sign msg [2/3] : 676e2074686973204353505220746f6b65",
+      "0 | Sign msg [3/3] : 6e20646f6e6174696f6e"
+    ],
+    "output_expert": [
+      "0 | Sign msg [1/3] : 4361737065723a0a506c65617365207369",
+      "0 | Sign msg [2/3] : 676e2074686973204353505220746f6b65",
+      "0 | Sign msg [3/3] : 6e20646f6e6174696f6e"
+    ]
+  },
+  {
+    "index": 517,
+    "name": "invalid-casper-message",
+    "valid_regular": false,
+    "valid_expert": false,
+    "testnet": true,
+    "blob": "636173706572206d6573736167653a0a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
+    "output": [
+      "0 | Sign msg [1/4] : 636173706572206d6573736167653a0a50",
+      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
+      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
+      "0 | Sign msg [4/4] : 6e"
+    ],
+    "output_expert": [
+      "0 | Sign msg [1/4] : 636173706572206d6573736167653a0a50",
+      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
+      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
+      "0 | Sign msg [4/4] : 6e"
+    ]
+  },
+  {
+    "index": 518,
+    "name": "invalid-casper-message",
+    "valid_regular": false,
+    "valid_expert": false,
+    "testnet": true,
+    "blob": "436173706572206d6573736167653a0a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
+    "output": [
+      "0 | Sign msg [1/4] : 436173706572206d6573736167653a0a50",
+      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
+      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
+      "0 | Sign msg [4/4] : 6e"
+    ],
+    "output_expert": [
+      "0 | Sign msg [1/4] : 436173706572206d6573736167653a0a50",
+      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
+      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
+      "0 | Sign msg [4/4] : 6e"
+    ]
   }
 ]

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -83,14 +83,12 @@ impl Element {
 #[derive(Clone)]
 #[allow(unused)]
 struct Ledger {
-    deploy: Deploy,
     ledger_elements: Vec<Element>,
 }
 
 impl Ledger {
     fn from_deploy(deploy: Deploy) -> Self {
         Ledger {
-            deploy: deploy.clone(),
             ledger_elements: parser::parse_deploy(deploy),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,17 +20,23 @@ fn main() {
 
     let limited_ledger_config = LimitedLedgerConfig::new(page_limit);
 
-    let data: Vec<ZondaxRepr> = undelegate_samples(&mut rng)
+    let mut id = 0;
+    let mut data: Vec<ZondaxRepr> = vec![];
+
+    for sample_deploy in undelegate_samples(&mut rng)
         .into_iter()
         .chain(delegate_samples(&mut rng))
         .chain(native_transfer_samples(&mut rng))
         .chain(redelegate_samples(&mut rng))
         .chain(generic_samples(&mut rng))
-        .enumerate()
-        .map(|(id, sample_deploy)| {
-            ledger::deploy_to_json(id, sample_deploy, &limited_ledger_config)
-        })
-        .collect();
+    {
+        data.push(ledger::deploy_to_json(
+            id,
+            sample_deploy,
+            &limited_ledger_config,
+        ));
+        id += 1;
+    }
 
     println!("{}", serde_json::to_string_pretty(&data).unwrap());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,11 @@ use test_data::{
 };
 use test_rng::TestRng;
 
+use crate::test_data::sign_message::{invalid_casper_message_sample, valid_casper_message_sample};
+
 pub mod checksummed_hex;
 mod ledger;
+mod message;
 mod parser;
 mod sample;
 mod test_data;
@@ -33,6 +36,18 @@ fn main() {
         data.push(ledger::deploy_to_json(
             id,
             sample_deploy,
+            &limited_ledger_config,
+        ));
+        id += 1;
+    }
+
+    for sample_casper_message in valid_casper_message_sample()
+        .into_iter()
+        .chain(invalid_casper_message_sample())
+    {
+        data.push(ledger::message_to_json(
+            id,
+            sample_casper_message,
             &limited_ledger_config,
         ));
         id += 1;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,29 @@
+/// It became a de-facto standard in Casper network that messsages for signing
+/// are prepended with the following prefix.
+const MSG_PREFIX: &str = "Casper Message:\n";
+
+pub(crate) struct CasperMessage(Vec<u8>);
+
+impl CasperMessage {
+    /// Create correct instance of `CasperMessage`
+    ///
+    /// NOTE: It became a de-facto standard that all Casper message for signing
+    /// are prepended with `Casper Message:\n`
+    pub(crate) fn new(msg: Vec<u8>) -> Self {
+        let mut output = MSG_PREFIX.as_bytes().to_vec();
+        output.extend(msg);
+        CasperMessage(output)
+    }
+
+    /// Bypasses the valid header prefix.
+    ///
+    /// WARNING: Allows for creating invalid instances of `CasperMessage`.
+    pub(crate) fn raw(msg: Vec<u8>) -> Self {
+        CasperMessage(msg)
+    }
+
+    /// Returns reference to the underlying bytes.
+    pub(crate) fn inner(&self) -> &[u8] {
+        &self.0
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,8 +8,13 @@ use casper_node::types::Deploy;
 use crate::{
     checksummed_hex,
     ledger::{Element, TxnPhase},
+    message::CasperMessage,
     parser::deploy::{parse_approvals, parse_deploy_header, parse_phase},
 };
+
+pub(crate) fn parse_message(m: CasperMessage) -> Vec<Element> {
+    vec![Element::regular("Sign msg", hex::encode(m.inner()))]
+}
 
 pub(crate) fn parse_deploy(d: Deploy) -> Vec<Element> {
     let mut elements = vec![];

--- a/src/test_data.rs
+++ b/src/test_data.rs
@@ -18,6 +18,7 @@ mod auction;
 mod commons;
 mod generic;
 mod native_transfer;
+pub(crate) mod sign_message;
 mod system_payment;
 
 // From the chainspec.

--- a/src/test_data/sign_message.rs
+++ b/src/test_data/sign_message.rs
@@ -1,0 +1,36 @@
+use crate::{message::CasperMessage, sample::Sample};
+
+const SAMPLE_MESSAGE: &str = "Please sign this CSPR token donation";
+
+/// Returns sample with valid CasperMessage for signing.
+pub(crate) fn valid_casper_message_sample() -> Vec<Sample<CasperMessage>> {
+    vec![Sample::new(
+        "valid-casper-message",
+        CasperMessage::new(SAMPLE_MESSAGE.as_bytes().to_vec()),
+        true,
+    )]
+}
+
+/// Returns invalid sample of CasperMessage for signing.
+pub(crate) fn invalid_casper_message_sample() -> Vec<Sample<CasperMessage>> {
+    let invalid_header = vec![
+        "Casper:",
+        "CasperMessage:",
+        "Casper:\n",
+        "casper message:\n",
+        "Casper message:\n",
+    ]
+    .into_iter()
+    .map(|prefix| prefix.as_bytes().to_vec());
+
+    let msg = SAMPLE_MESSAGE.as_bytes();
+
+    invalid_header
+        .map(|prefix| {
+            let mut output: Vec<u8> = prefix;
+            output.extend(msg.clone());
+            let message = CasperMessage::raw(output);
+            Sample::new("invalid-casper-message", message, false)
+        })
+        .collect()
+}


### PR DESCRIPTION
Adds test vectors that cover signing message.

NOTE that all _VALID_ messages have to be prepended with **exact** prefix: `Casper message:\n`. I've included a couple invalid examples that prepend with the following:
* `Casper:`
* `CasperMessage:`
* `Casper:\n`
* `casper message:\n`
* `Casper message:\n`