### PR TITLE
Sign message blake2b hash

### DIFF
--- a/manual.json
+++ b/manual.json
@@ -23285,116 +23285,98 @@
   },
   {
     "index": 513,
-    "name": "valid-casper-message",
+    "name": "valid_casper_message",
     "valid_regular": true,
     "valid_expert": true,
     "testnet": true,
     "blob": "436173706572204d6573736167653a0a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
     "output": [
-      "0 | Sign msg [1/4] : 436173706572204d6573736167653a0a50",
-      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
-      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
-      "0 | Sign msg [4/4] : 6e"
+      "0 | Msg hash [1/2] : 14454e19804a72966fe92ae0ebc9846e0c",
+      "0 | Msg hash [2/2] : 8bb5b4d706e7e809a82b3cc99488b6"
     ],
     "output_expert": [
-      "0 | Sign msg [1/4] : 436173706572204d6573736167653a0a50",
-      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
-      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
-      "0 | Sign msg [4/4] : 6e"
+      "0 | Msg hash [1/2] : 14454e19804a72966fe92ae0ebc9846e0c",
+      "0 | Msg hash [2/2] : 8bb5b4d706e7e809a82b3cc99488b6"
     ]
   },
   {
     "index": 514,
-    "name": "invalid-casper-message",
+    "name": "invalid_casper_message",
     "valid_regular": false,
     "valid_expert": false,
     "testnet": true,
     "blob": "4361737065723a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
     "output": [
-      "0 | Sign msg [1/3] : 4361737065723a506c6561736520736967",
-      "0 | Sign msg [2/3] : 6e2074686973204353505220746f6b656e",
-      "0 | Sign msg [3/3] : 20646f6e6174696f6e"
+      "0 | Msg hash [1/2] : 2931dc5c6d6745a221b98a04951d7c2c86",
+      "0 | Msg hash [2/2] : f5a9e92a8dbffe30abb19ec7ff9ee0"
     ],
     "output_expert": [
-      "0 | Sign msg [1/3] : 4361737065723a506c6561736520736967",
-      "0 | Sign msg [2/3] : 6e2074686973204353505220746f6b656e",
-      "0 | Sign msg [3/3] : 20646f6e6174696f6e"
+      "0 | Msg hash [1/2] : 2931dc5c6d6745a221b98a04951d7c2c86",
+      "0 | Msg hash [2/2] : f5a9e92a8dbffe30abb19ec7ff9ee0"
     ]
   },
   {
     "index": 515,
-    "name": "invalid-casper-message",
+    "name": "invalid_casper_message",
     "valid_regular": false,
     "valid_expert": false,
     "testnet": true,
     "blob": "4361737065724d6573736167653a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
     "output": [
-      "0 | Sign msg [1/3] : 4361737065724d6573736167653a506c65",
-      "0 | Sign msg [2/3] : 617365207369676e207468697320435350",
-      "0 | Sign msg [3/3] : 5220746f6b656e20646f6e6174696f6e"
+      "0 | Msg hash [1/2] : 6f0ad8b6b380b90a36c0e9052750861925",
+      "0 | Msg hash [2/2] : 9b19d11d359968eafb78f92a939d2f"
     ],
     "output_expert": [
-      "0 | Sign msg [1/3] : 4361737065724d6573736167653a506c65",
-      "0 | Sign msg [2/3] : 617365207369676e207468697320435350",
-      "0 | Sign msg [3/3] : 5220746f6b656e20646f6e6174696f6e"
+      "0 | Msg hash [1/2] : 6f0ad8b6b380b90a36c0e9052750861925",
+      "0 | Msg hash [2/2] : 9b19d11d359968eafb78f92a939d2f"
     ]
   },
   {
     "index": 516,
-    "name": "invalid-casper-message",
+    "name": "invalid_casper_message",
     "valid_regular": false,
     "valid_expert": false,
     "testnet": true,
     "blob": "4361737065723a0a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
     "output": [
-      "0 | Sign msg [1/3] : 4361737065723a0a506c65617365207369",
-      "0 | Sign msg [2/3] : 676e2074686973204353505220746f6b65",
-      "0 | Sign msg [3/3] : 6e20646f6e6174696f6e"
+      "0 | Msg hash [1/2] : 114d55ed2ccbe8345cb9a223810927a0a8",
+      "0 | Msg hash [2/2] : 6aed94a262d82de89890bc2686dfc8"
     ],
     "output_expert": [
-      "0 | Sign msg [1/3] : 4361737065723a0a506c65617365207369",
-      "0 | Sign msg [2/3] : 676e2074686973204353505220746f6b65",
-      "0 | Sign msg [3/3] : 6e20646f6e6174696f6e"
+      "0 | Msg hash [1/2] : 114d55ed2ccbe8345cb9a223810927a0a8",
+      "0 | Msg hash [2/2] : 6aed94a262d82de89890bc2686dfc8"
     ]
   },
   {
     "index": 517,
-    "name": "invalid-casper-message",
+    "name": "invalid_casper_message",
     "valid_regular": false,
     "valid_expert": false,
     "testnet": true,
     "blob": "636173706572206d6573736167653a0a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
     "output": [
-      "0 | Sign msg [1/4] : 636173706572206d6573736167653a0a50",
-      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
-      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
-      "0 | Sign msg [4/4] : 6e"
+      "0 | Msg hash [1/2] : e7e876a45dbdc504553cf4775b1c4a166e",
+      "0 | Msg hash [2/2] : 0e6d69c1268a0f773f4cbb62916fa1"
     ],
     "output_expert": [
-      "0 | Sign msg [1/4] : 636173706572206d6573736167653a0a50",
-      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
-      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
-      "0 | Sign msg [4/4] : 6e"
+      "0 | Msg hash [1/2] : e7e876a45dbdc504553cf4775b1c4a166e",
+      "0 | Msg hash [2/2] : 0e6d69c1268a0f773f4cbb62916fa1"
     ]
   },
   {
     "index": 518,
-    "name": "invalid-casper-message",
+    "name": "invalid_casper_message",
     "valid_regular": false,
     "valid_expert": false,
     "testnet": true,
     "blob": "436173706572206d6573736167653a0a506c65617365207369676e2074686973204353505220746f6b656e20646f6e6174696f6e",
     "output": [
-      "0 | Sign msg [1/4] : 436173706572206d6573736167653a0a50",
-      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
-      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
-      "0 | Sign msg [4/4] : 6e"
+      "0 | Msg hash [1/2] : 7704cdabfdafae206340ee4bd960bf3de0",
+      "0 | Msg hash [2/2] : e28cc543d15a6a033594cd2f18ca34"
     ],
     "output_expert": [
-      "0 | Sign msg [1/4] : 436173706572206d6573736167653a0a50",
-      "0 | Sign msg [2/4] : 6c65617365207369676e20746869732043",
-      "0 | Sign msg [3/4] : 53505220746f6b656e20646f6e6174696f",
-      "0 | Sign msg [4/4] : 6e"
+      "0 | Msg hash [1/2] : 7704cdabfdafae206340ee4bd960bf3de0",
+      "0 | Msg hash [2/2] : e28cc543d15a6a033594cd2f18ca34"
     ]
   }
 ]

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,5 @@
+use casper_types::{blake2b, BLAKE2B_DIGEST_LENGTH};
+
 /// It became a de-facto standard in Casper network that messsages for signing
 /// are prepended with the following prefix.
 const MSG_PREFIX: &str = "Casper Message:\n";
@@ -25,5 +27,10 @@ impl CasperMessage {
     /// Returns reference to the underlying bytes.
     pub(crate) fn inner(&self) -> &[u8] {
         &self.0
+    }
+
+    /// Returns blake2b hash of the underlying bytes.
+    pub(crate) fn hashed(&self) -> [u8; BLAKE2B_DIGEST_LENGTH] {
+        blake2b(&self.0)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub(crate) fn parse_message(m: CasperMessage) -> Vec<Element> {
-    vec![Element::regular("Sign msg", hex::encode(m.inner()))]
+    vec![Element::regular("Msg hash", hex::encode(m.hashed()))]
 }
 
 pub(crate) fn parse_deploy(d: Deploy) -> Vec<Element> {

--- a/src/test_data/sign_message.rs
+++ b/src/test_data/sign_message.rs
@@ -5,7 +5,7 @@ const SAMPLE_MESSAGE: &str = "Please sign this CSPR token donation";
 /// Returns sample with valid CasperMessage for signing.
 pub(crate) fn valid_casper_message_sample() -> Vec<Sample<CasperMessage>> {
     vec![Sample::new(
-        "valid-casper-message",
+        "valid_casper_message",
         CasperMessage::new(SAMPLE_MESSAGE.as_bytes().to_vec()),
         true,
     )]
@@ -30,7 +30,7 @@ pub(crate) fn invalid_casper_message_sample() -> Vec<Sample<CasperMessage>> {
             let mut output: Vec<u8> = prefix;
             output.extend(msg.clone());
             let message = CasperMessage::raw(output);
-            Sample::new("invalid-casper-message", message, false)
+            Sample::new("invalid_casper_message", message, false)
         })
         .collect()
 }


### PR DESCRIPTION
Notable changes:
* Instead of displaying hex-encoded raw message bytes for signing we display hex-encoded blake2b hash of the message.
* label for message being signed changed from `Sign msg` to `Msg hash` to reflect that.


Also, replaces `-` with `_` in the test vectors' labels.