### PR TITLE
Only display transaction hash for large WASMs, fix optional transfer id

### DIFF
--- a/src/parser/v1.rs
+++ b/src/parser/v1.rs
@@ -172,11 +172,26 @@ pub(crate) fn parse_v1_meta(v1: &TransactionV1) -> Vec<Element> {
             }
             elements
         }
-        TransactionTarget::Session { .. } => {
+        TransactionTarget::Session { module_bytes, .. } => {
+            // Session transactions with wasm size exceeding 16kb will not display
+            // any extra information due to hardware limitations.
+            if module_bytes.len() >= 16_384 {
+                return vec![];
+            }
+
             let mut elements = v1_type(&meta);
             match meta.args {
                 TransactionArgs::Named(args) => {
-                    elements.extend(parse_runtime_args_v1(&args));
+                    if is_system_payment(module_bytes) {
+                        elements.extend(parse_fee(&args));
+                        let args_sans_amount = remove_amount_arg(args.clone());
+                        if !args_sans_amount.is_empty() {
+                            elements.extend(parse_runtime_args_v1(&args));
+                        }
+                    } else {
+                        elements.extend(parse_amount(&args));
+                        elements.extend(parse_runtime_args_v1(&args));
+                    }
                 }
                 TransactionArgs::Bytesrepr(bytes) => {
                     elements.extend(parse_bytesrepr_args(bytes));

--- a/src/parser/v1.rs
+++ b/src/parser/v1.rs
@@ -175,7 +175,7 @@ pub(crate) fn parse_v1_meta(v1: &TransactionV1) -> Vec<Element> {
         TransactionTarget::Session { module_bytes, .. } => {
             // Session transactions with wasm size exceeding 16kb will not display
             // any extra information due to hardware limitations.
-            if module_bytes.len() >= 16_384 {
+            if module_bytes.len() > 16_384 {
                 return vec![];
             }
 

--- a/src/parser/v1.rs
+++ b/src/parser/v1.rs
@@ -172,20 +172,11 @@ pub(crate) fn parse_v1_meta(v1: &TransactionV1) -> Vec<Element> {
             }
             elements
         }
-        TransactionTarget::Session { module_bytes, .. } => {
-            let mut elements: Vec<Element> = v1_type(&meta);
+        TransactionTarget::Session { .. } => {
+            let mut elements = v1_type(&meta);
             match meta.args {
                 TransactionArgs::Named(args) => {
-                    if is_system_payment(module_bytes) {
-                        elements.extend(parse_fee(&args));
-                        let args_sans_amount = remove_amount_arg(args.clone());
-                        if !args_sans_amount.is_empty() {
-                            elements.extend(parse_runtime_args_v1(&args));
-                        }
-                    } else {
-                        elements.extend(parse_amount(&args));
-                        elements.extend(parse_runtime_args_v1(&args));
-                    }
+                    elements.extend(parse_runtime_args_v1(&args));
                 }
                 TransactionArgs::Bytesrepr(bytes) => {
                     elements.extend(parse_bytesrepr_args(bytes));

--- a/src/test_data/commons.rs
+++ b/src/test_data/commons.rs
@@ -86,7 +86,7 @@ pub(crate) fn sample_large_module_bytes(ra: RuntimeArgs) -> Sample<ExecutableDep
     Sample::new(
         "type_large_module_bytes",
         ExecutableDeployItem::ModuleBytes {
-            module_bytes: Bytes::from([1u8; 16384].to_vec()),
+            module_bytes: Bytes::from([1u8; 16385].to_vec()),
             args: ra,
         },
         true,

--- a/src/test_data/commons.rs
+++ b/src/test_data/commons.rs
@@ -82,6 +82,17 @@ pub(crate) fn sample_module_bytes(ra: RuntimeArgs) -> Sample<ExecutableDeployIte
     )
 }
 
+pub(crate) fn sample_large_module_bytes(ra: RuntimeArgs) -> Sample<ExecutableDeployItem> {
+    Sample::new(
+        "type_large_module_bytes",
+        ExecutableDeployItem::ModuleBytes {
+            module_bytes: Bytes::from([1u8; 16384].to_vec()),
+            args: ra,
+        },
+        true,
+    )
+}
+
 // Prepends `entrypoint` to the current label of `sample`.
 pub(crate) fn prepend_label(
     sample: Sample<ExecutableDeployItem>,

--- a/src/test_data/generic.rs
+++ b/src/test_data/generic.rs
@@ -18,7 +18,7 @@ use strum::{EnumIter, IntoEnumIterator};
 
 use crate::{
     sample::Sample,
-    test_data::commons::{sample_executables, sample_module_bytes},
+    test_data::commons::{sample_executables, sample_large_module_bytes, sample_module_bytes},
 };
 
 use super::commons::UREF_ADDR;
@@ -30,6 +30,7 @@ pub(crate) fn valid<R: Rng>(rng: &mut R) -> Vec<Sample<ExecutableDeployItem>> {
     let mut output = Vec::with_capacity(rargs.len());
 
     output.push(sample_module_bytes(rargs.first().cloned().unwrap()));
+    output.push(sample_large_module_bytes(rargs.first().cloned().unwrap()));
 
     for args in rargs {
         for sample in sample_executables(ENTRYPOINT, args.clone(), None, true) {

--- a/src/test_data/native_transfer.rs
+++ b/src/test_data/native_transfer.rs
@@ -17,7 +17,12 @@ pub(crate) struct NativeTransfer {
 }
 
 impl NativeTransfer {
-    pub fn new(target: TransferTarget, amount: U512, id: Option<u64>, source: TransferSource) -> Self {
+    pub fn new(
+        target: TransferTarget,
+        amount: U512,
+        id: Option<u64>,
+        source: TransferSource,
+    ) -> Self {
         NativeTransfer {
             target,
             amount,
@@ -164,7 +169,11 @@ pub(crate) fn native_transfer_samples(
                     } else {
                         "none".into()
                     };
-                    let label = format!("native_transfer_{}_{}_id_{id_label}", target.label(), source.label());
+                    let label = format!(
+                        "native_transfer_{}_{}_id_{id_label}",
+                        target.label(),
+                        source.label()
+                    );
                     let nt = NativeTransfer::new(target.clone(), *amount, *id, source.clone());
                     let sample = Sample::new(label, nt, true);
                     samples.push(sample);

--- a/src/test_data/native_transfer.rs
+++ b/src/test_data/native_transfer.rs
@@ -12,12 +12,12 @@ use super::commons::UREF_ADDR;
 pub(crate) struct NativeTransfer {
     target: TransferTarget,
     amount: U512,
-    id: u64,
+    id: Option<u64>,
     source: TransferSource,
 }
 
 impl NativeTransfer {
-    pub fn new(target: TransferTarget, amount: U512, id: u64, source: TransferSource) -> Self {
+    pub fn new(target: TransferTarget, amount: U512, id: Option<u64>, source: TransferSource) -> Self {
         NativeTransfer {
             target,
             amount,
@@ -31,7 +31,9 @@ impl From<NativeTransfer> for RuntimeArgs {
     fn from(nt: NativeTransfer) -> Self {
         let mut ra = RuntimeArgs::new();
         ra.insert("amount", nt.amount).unwrap();
-        ra.insert("id", Some(nt.id)).unwrap();
+        if let Some(id) = nt.id {
+            ra.insert("id", Some(id)).unwrap();
+        }
         if let TransferSource::URef(uref) = nt.source {
             ra.insert("source", uref).unwrap();
         }
@@ -147,7 +149,7 @@ impl TransferTarget {
 /// for every combination of them creates a `NativeTransfer` sample.
 pub(crate) fn native_transfer_samples(
     amounts: &[U512],
-    transfer_id: &[u64],
+    transfer_id: &[Option<u64>],
     targets: &[TransferTarget],
     sources: &[TransferSource],
 ) -> Vec<Sample<NativeTransfer>> {
@@ -157,7 +159,12 @@ pub(crate) fn native_transfer_samples(
         for id in transfer_id {
             for target in targets {
                 for source in sources {
-                    let label = format!("native_transfer_{}_{}", target.label(), source.label());
+                    let id_label = if let Some(id) = *id {
+                        id.to_string()
+                    } else {
+                        "none".into()
+                    };
+                    let label = format!("native_transfer_{}_{}_id_{id_label}", target.label(), source.label());
                     let nt = NativeTransfer::new(target.clone(), *amount, *id, source.clone());
                     let sample = Sample::new(label, nt, true);
                     samples.push(sample);
@@ -177,7 +184,7 @@ pub(super) fn valid() -> Vec<Sample<ExecutableDeployItem>> {
     let amounts = vec![amount_min, amount_mid, amount_max];
     let id_min = u64::MIN;
     let id_max = u64::MAX;
-    let transfer_id = vec![id_min, id_max];
+    let transfer_id = vec![Some(id_min), Some(id_max), None];
     let targets = vec![
         TransferTarget::bytes(),
         TransferTarget::uref(),

--- a/src/test_data/native_v1/transfer.rs
+++ b/src/test_data/native_v1/transfer.rs
@@ -21,7 +21,7 @@ pub(crate) fn valid() -> Vec<Sample<TransactionV1Meta>> {
     let amounts = vec![amount_min, amount_mid, amount_max];
     let id_min = u64::MIN;
     let id_max = u64::MAX;
-    let transfer_id = vec![id_min, id_max];
+    let transfer_id = vec![Some(id_min), Some(id_max), None];
     let targets = vec![
         TransferTarget::bytes(),
         TransferTarget::uref(),
@@ -57,10 +57,6 @@ pub(crate) fn invalid() -> Vec<Sample<TransactionV1Meta>> {
         "id" => 1u64,
         "target" => URef::new(UREF_ADDR, AccessRights::READ),
     };
-    let missing_required_id: RuntimeArgs = runtime_args! {
-        "amount" => U512::from(100000000u64),
-        "target" => URef::new(UREF_ADDR, AccessRights::READ),
-    };
     let missing_required_target: RuntimeArgs = runtime_args! {
         "amount" => U512::from(100000000u64),
         "id" => 1u64,
@@ -73,7 +69,6 @@ pub(crate) fn invalid() -> Vec<Sample<TransactionV1Meta>> {
 
     let invalid_transfer_args: Vec<Sample<RuntimeArgs>> = vec![
         Sample::new("missing_amount", missing_required_amount, false),
-        Sample::new("missing_id", missing_required_id, false),
         Sample::new("missing_target", missing_required_target, false),
         Sample::new("invalid_type_amount", invalid_amount_type, false),
     ];


### PR DESCRIPTION
It was noted that due to hardware limitations, large payloads would only display transaction hashes. This PR aligns the test vectors with this behavior. Additionally, fixes an oversight whereby 'id' runtime arg for transfer has been marked as required.