### PR TITLE
Handle large WASM display

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,8 +3,10 @@ mod runtime_args;
 mod utils;
 pub(crate) mod v1;
 
-use casper_types::{Deploy, TransactionEntryPoint, TransactionV1};
-use v1::{parse_v1_approvals, parse_v1_meta, parse_v1_payload, ENTRY_POINT_MAP_KEY};
+use casper_types::{Deploy, TransactionEntryPoint, TransactionTarget, TransactionV1};
+use v1::{
+    parse_v1_approvals, parse_v1_meta, parse_v1_payload, TransactionV1Meta, ENTRY_POINT_MAP_KEY,
+};
 
 use crate::{
     checksummed_hex,
@@ -37,6 +39,16 @@ pub(crate) fn parse_v1(v1: TransactionV1) -> Vec<Element> {
         "Txn hash",
         checksummed_hex::encode(v1.hash().inner()).to_string(),
     ));
+
+    let meta = TransactionV1Meta::deserialize_from(&v1);
+    if let TransactionTarget::Session { module_bytes, .. } = meta.target {
+        // Session transactions with wasm size exceeding 16kb will not display
+        // any extra information due to hardware limitations.
+        if module_bytes.len() > 16_383 {
+            return elements;
+        }
+    }
+
     elements.push(transaction_v1_type(&v1));
     elements.extend(parse_v1_payload(v1.payload()));
     elements.extend(parse_v1_meta(&v1));

--- a/src/parser/v1.rs
+++ b/src/parser/v1.rs
@@ -175,7 +175,7 @@ pub(crate) fn parse_v1_meta(v1: &TransactionV1) -> Vec<Element> {
         TransactionTarget::Session { module_bytes, .. } => {
             // Session transactions with wasm size exceeding 16kb will not display
             // any extra information due to hardware limitations.
-            if module_bytes.len() > 16_384 {
+            if module_bytes.len() > 16_383 {
                 return vec![];
             }
 

--- a/src/parser/v1.rs
+++ b/src/parser/v1.rs
@@ -173,12 +173,6 @@ pub(crate) fn parse_v1_meta(v1: &TransactionV1) -> Vec<Element> {
             elements
         }
         TransactionTarget::Session { module_bytes, .. } => {
-            // Session transactions with wasm size exceeding 16kb will not display
-            // any extra information due to hardware limitations.
-            if module_bytes.len() > 16_383 {
-                return vec![];
-            }
-
             let mut elements = v1_type(&meta);
             match meta.args {
                 TransactionArgs::Named(args) => {

--- a/src/test_data/native_transfer.rs
+++ b/src/test_data/native_transfer.rs
@@ -238,10 +238,6 @@ pub(super) fn invalid() -> Vec<Sample<ExecutableDeployItem>> {
         "id" => 1u64,
         "target" => URef::new(UREF_ADDR, AccessRights::READ),
     };
-    let missing_required_id: RuntimeArgs = runtime_args! {
-        "amount" => U512::from(100000000u64),
-        "target" => URef::new(UREF_ADDR, AccessRights::READ),
-    };
     let missing_required_target: RuntimeArgs = runtime_args! {
         "amount" => U512::from(100000000u64),
         "id" => 1u64,
@@ -254,7 +250,6 @@ pub(super) fn invalid() -> Vec<Sample<ExecutableDeployItem>> {
 
     let invalid_transfer_args: Vec<Sample<RuntimeArgs>> = vec![
         Sample::new("missing_amount", missing_required_amount, false),
-        Sample::new("missing_id", missing_required_id, false),
         Sample::new("missing_target", missing_required_target, false),
         Sample::new("invalid_type_amount", invalid_amount_type, false),
     ];


### PR DESCRIPTION
Due to technical limitations, only the transaction hash is displayed for large WASMs. This PR updates the generator to align with that behavior. It also fixes an issue where the ``id`` field of ``NativeTransfer`` was incorrectly marked as required.